### PR TITLE
fix css charcode, attach more css to template, specify css fontFamily

### DIFF
--- a/_icons.scss
+++ b/_icons.scss
@@ -1,4 +1,13 @@
-<% _.each(glyphs, function(glyph) { %>.<%= glyph.filename %> {
-	content: "\u<%= glyph.codepoint %>";
+.icon {
+    font-size: 32px;
+    font-family: "<%=fontFamily%>";
+    display: inline-block;
+    font-style: normal;
+    speak: none;
+    -webkit-font-smoothing: antialiased;
+}
+
+<% _.each(glyphs, function(glyph) { %>.icon-<%= glyph.filename %>:before {
+    content: "\e<%= glyph.unicode %>";
 }
 <% }); %>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,14 @@ function iconfontCSS(config) {
 		path: __dirname + '/_icons.scss',
 		targetPath: '_icons.scss',
 		engine: 'lodash',
-		firstGlyph: 0xE001
+		firstGlyph: 0xE001,
+		fontFamily: false
 	}, config);
 
 	// Validate config
+	if (!config.fontFamily) {
+		throw new gutil.PluginError(PLUGIN_NAME, 'You must specify a fontFamily');
+	}
 	if (!consolidate[config.engine]) {
 		throw new gutil.PluginError(PLUGIN_NAME, 'Consolidate missing template engine "' + config.engine + '"');
 	}
@@ -61,7 +65,8 @@ function iconfontCSS(config) {
 		// Add glyph
 		glyphMap.push({
 			filename: path.basename(file.path, '.svg'),
-			codepoint: currentGlyph
+			codepoint: currentGlyph,
+			unicode: currentGlyph.toString(16).toUpperCase().substring(1)
 		});
 
 		// Prepend codepoint to input file path for gulp-iconfont
@@ -81,7 +86,8 @@ function iconfontCSS(config) {
 
 		if (glyphMap.length) {
 			consolidate[config.engine](config.path, {
-					glyphs: glyphMap
+					glyphs: glyphMap,
+					fontFamily : config.fontFamily
 				}, function(error, html) {
 					if (error) {
 						throw error;


### PR DESCRIPTION
Hi there,
I couldnt get it working without these changes. Maybe they are useful for you.

First the generated css contained not the correct unicode because the unicode character had been passed without converting it into a string. This resulted in wrong character codes in the css files (at least in my system). 

Second i added more css on top of the template which is useful for all icons. I took it from my old grunt iconfont stuff. 

The task now expects also a css font family which is used in the scss template also:
gulp.src(['./public/assets/svg/*.svg'])
            .pipe(iconfontCss({
                path: './public/assets/sass/__gulp-iconfont.scss',
                targetPath: '../sass/__icons.scss', // relative to gulp.dest below
                fontFamily: 'app Icons' // css fontfamily required
            }))
            .pipe(iconfont({
                fontName: 'app-Icons', // required
                appendCodepoints: true // recommanded option
            }))
            .pipe(gulp.dest('./public/assets/fonts'));
