### PR TITLE
Allow to set the pseudo-element used for the icon

### DIFF
--- a/templates/_icons.scss
+++ b/templates/_icons.scss
@@ -29,8 +29,10 @@
 	@return $char;
 }
 
-@mixin icon($filename) {
-	&:before {
+@mixin icon($filename, $position: left) {
+	$pseudo-element: if($position == left, before, after);
+
+	&:#{$pseudo-element} {
 		@extend %icon;
 		content: icon-char($filename);
 	}


### PR DESCRIPTION
Update the Sass mixin so that the pseudo-element used can be specified by the developer. This change ensures backwards compatibility by defaulting to `:before`.
