### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function iconfontCSS(config) {
 			outputFile = new gutil.File({
 				base: file.base,
 				cwd: file.cwd,
-				path: path.join(file.base, config.targetPath),
+				path: path.resolve(file.base, config.targetPath),
 				contents: file.isBuffer() ? new Buffer(0) : new Stream.PassThrough()
 			});
 		}


### PR DESCRIPTION
This fixes the osx issues encountered various places regarding scss files being generated in wrong directories, or not at all.

this however requires you to realize that targetpath (as described in the readme) is relative to dest, so userconfig errors may throw this.

-k
