### PR TITLE
Compatibility with gulp-iconfont 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash": "~3.10.0"
   },
   "peerDependencies": {
-    "gulp-iconfont": "~4.0.0"
+    "gulp-iconfont": ">=4.0.0 <6.0.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
The gulp-iconfont 5.0.0 release added support for node 4.x and did some other internal cleanup, but doesn't appear to have changed the API. I did some quick testing, and aside from npm complaining about the peer dependency mismatch, I don't see any issues with running gulp-iconfont-css v1.0.1 and gulp-iconfont 5.0.0 together.

Fixes #29 