### PR TITLE
Use Buffer.from to to remove deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,12 @@ function iconfontCSS(config) {
 						throw new gutil.PluginError(PLUGIN_NAME, 'Error in template: ' + err.message);
 					}
 
-					content = Buffer.from(html);
+					// TODO: remove condition and the else block for version 3.0
+					if( Buffer.from ){
+						content = Buffer.from(html);
+					}else{
+						content = Buffer(html);
+					}
 
 					if (outputFile.isBuffer()) {
 						outputFile.contents = content;

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ function iconfontCSS(config) {
 						throw new gutil.PluginError(PLUGIN_NAME, 'Error in template: ' + err.message);
 					}
 
-					content = Buffer(html);
+					content = Buffer.from(html);
 
 					if (outputFile.isBuffer()) {
 						outputFile.contents = content;


### PR DESCRIPTION
Using this plugin with node7 outputs this warning to the console
> DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.