### PR TITLE
Replace gulp-util with individual packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var path = require('path'),
-	gutil = require('gulp-util'),
+	PluginError = require('plugin-error'),
+	Vinyl = require('vinyl'),
 	consolidate = require('consolidate'),
 	_ = require('lodash'),
 	Stream = require('stream');
@@ -41,15 +42,15 @@ function iconfontCSS(config) {
 
 	// Validate config
 	if (!config.fontName) {
-		throw new gutil.PluginError(PLUGIN_NAME, 'Missing option "fontName"');
+		throw new PluginError(PLUGIN_NAME, 'Missing option "fontName"');
 	}
 	if (!consolidate[config.engine]) {
-		throw new gutil.PluginError(PLUGIN_NAME, 'Consolidate missing template engine "' + config.engine + '"');
+		throw new PluginError(PLUGIN_NAME, 'Consolidate missing template engine "' + config.engine + '"');
 	}
 	try {
 		engine = require(config.engine);
 	} catch(e) {
-		throw new gutil.PluginError(PLUGIN_NAME, 'Template engine "' + config.engine + '" not present');
+		throw new PluginError(PLUGIN_NAME, 'Template engine "' + config.engine + '" not present');
 	}
 
 	// Define starting point
@@ -70,7 +71,7 @@ function iconfontCSS(config) {
 
 		// Create output file
 		if (!outputFile) {
-			outputFile = new gutil.File({
+			outputFile = new Vinyl({
 				base: file.base,
 				cwd: file.cwd,
 				path: path.join(file.base, config.targetPath),
@@ -123,7 +124,7 @@ function iconfontCSS(config) {
 					cacheBusterQueryString: config.cacheBuster ? '?' + config.cacheBuster : ''
 				}, function(err, html) {
 					if (err) {
-						throw new gutil.PluginError(PLUGIN_NAME, 'Error in template: ' + err.message);
+						throw new PluginError(PLUGIN_NAME, 'Error in template: ' + err.message);
 					}
 
 					// TODO: remove condition and the else block for version 3.0

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "css"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.6",
     "consolidate": "^0.13.1",
-    "lodash": "^3.10.0"
+    "lodash": "^3.10.0",
+    "plugin-error": "^1.0.1",
+    "vinyl": "^2.2.0"
   },
   "devDependencies": {
     "del": "^2.2.0",


### PR DESCRIPTION
Really useful plugin! I want to contribute back. See more details here https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 & https://github.com/gulpjs/gulp-util/issues/143. Normally, they are just drop-in replacements so no risk of regression.