### PR TITLE
Locked event-stream to 3.3.4 due to vulnerability in newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "del": "^3.0.0",
-    "event-stream": "^4.0.1",
+    "event-stream": "3.3.4",
     "gulp": "^4.0.0",
     "gulp-iconfont": "^10.0.2",
     "mocha": "^5.2.0",


### PR DESCRIPTION
See https://github.com/dominictarr/event-stream/issues/116